### PR TITLE
Fix setting a config overrides old config

### DIFF
--- a/cmd/couik/cli/config_helpers.go
+++ b/cmd/couik/cli/config_helpers.go
@@ -29,7 +29,7 @@ func GetConfig() Config {
 }
 
 func SetConfig(key, value string) {
-	config := &Config{}
+	config := GetConfig()
 
 	availableKeys := []string{
 		"mode",


### PR DESCRIPTION
Load data first before updating the configuration