### PR TITLE
Added quote source attribution to results

### DIFF
--- a/pkg/ui/core/types.go
+++ b/pkg/ui/core/types.go
@@ -28,6 +28,7 @@ const (
 
 type ModeConfig struct {
 	Target       string
+	Source       string
 	Duration     int
 	InitialWords int
 	Language     database.Language

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -42,6 +42,9 @@ type Model struct {
 	QuoteType            database.QuoteCategory
 	IsSelectingQuoteType bool
 
+	// quote attribution
+	QuoteSource string
+
 	// words
 	InitialWords int
 
@@ -197,6 +200,7 @@ func (m Model) ApplyMode(mode modes.ModeStrategy, options ...ApplyModelOption) M
 
 	newModel.Mode = mode
 	newModel.CurrentLanguage = config.Language
+	newModel.QuoteSource = config.Source
 	newModel.InitialWords = config.InitialWords
 	newModel.QuoteType = config.Category
 

--- a/pkg/ui/modes/quote.go
+++ b/pkg/ui/modes/quote.go
@@ -9,6 +9,7 @@ import (
 
 type QuoteMode struct {
 	Target   string
+	Source   string
 	Language database.Language
 	Category database.QuoteCategory
 }
@@ -18,6 +19,7 @@ type QuoteOption func(qm *QuoteMode)
 func NewQuoteMode(options ...QuoteOption) *QuoteMode {
 	qm := &QuoteMode{
 		Target:   typing.GetQuoteUseCase(database.English, database.Mid).Text,
+		Source:   typing.GetQuoteUseCase(database.English, database.Mid).Source,
 		Language: database.English,
 		Category: database.Mid,
 	}
@@ -72,6 +74,7 @@ func (qm QuoteMode) ProcessTick(ctx TickContext) tea.Cmd {
 func (qm QuoteMode) GetConfig() core.ModeConfig {
 	return core.ModeConfig{
 		Target:   qm.GetTarget(),
+		Source:   qm.Source,
 		Language: qm.Language,
 		Category: qm.Category,
 	}

--- a/pkg/ui/result_view.go
+++ b/pkg/ui/result_view.go
@@ -110,6 +110,16 @@ func (m Model) resultsView() string {
 	footerKey := lipgloss.NewStyle().Foreground(CatLavender).Bold(true)
 	footerDesc := lipgloss.NewStyle().Foreground(CatOverlay)
 
+	var attribution string
+	if m.QuoteSource != "" {
+		maxWidth := 80
+		label := "Quote from: " + m.QuoteSource
+		if len(label) > maxWidth {
+			label = label[:maxWidth-3] + "..."
+		}
+		attribution = lipgloss.NewStyle().Foreground(CatSubtext).Render(label)
+	}
+
 	var multiplayerStats string
 	if m.Multiplayer {
 		multiplayerStats = m.PlayersView()
@@ -157,6 +167,8 @@ func (m Model) resultsView() string {
 		mainRow,
 		"",
 		multiplayerStats,
+		"",
+		attribution,
 		"",
 		footer,
 		modeSelectorString,


### PR DESCRIPTION
I was curious about some of the quotes and wanted to know where they came from, so I added a "Quote from: <source>" line to the results screen when a source is available. Long strings truncate with an ellipsis. No visible change for quotes without a source.
